### PR TITLE
rimosso "ad esempio" da altri progetti mozilla

### DIFF
--- a/html/volantino_fronte.html
+++ b/html/volantino_fronte.html
@@ -15,15 +15,34 @@
                     Presentazione
                 </div>
                 <div id="descrizione">
-                    Innanzitutto è doveroso spiegare che cos'è <i>Firefox</i>. È un browser web <b>unico</b> che mette al primo posto gli utenti, ha il codice sorgente libero (quindi tutti possono analizzarlo e modificarlo), è disponibile per tutti i principali sistemi operativi, è personalizzabile, è versatile, è veloce e, molto importante, è <b>sicuro</b>.
+                    Innanzitutto è doveroso spiegare che cos'è <i>Firefox</i>.
+                    È un browser web <b>unico</b> che mette al primo posto gli utenti,
+                    ha il codice sorgente libero (quindi tutti possono analizzarlo e modificarlo),
+                    è disponibile per tutti i principali sistemi operativi,
+                    è personalizzabile, è versatile, è veloce e,
+                    molto importante, è <b>sicuro</b>.
                     <br>
-                    <b>Mozilla Foundation</b> è l'organizzazione <i>senza fini</i> di lucro che, da oltre 15 anni, supporta Firefox e altri numerosi progetti. Questa organizzazione ha più di 10.000 <b>volontari</b>, provenienti da ogni parte del <i>globo</i>.
+
+                    <b>Mozilla Foundation</b> è l'organizzazione
+                    <i>senza fini</i> di lucro che, da oltre 15 anni,
+                    supporta Firefox e altri numerosi progetti.
+                    Questa organizzazione ha più di 10.000 <b>volontari</b>,
+                    provenienti da ogni parte del <i>globo</i>.
                     <br>
-                    La comunità che opera in Italia prende il nome di <i>Mozilla Italia</i>; si occupa di tradurre progetti e siti web, ma anche di realizzare e partecipare a eventi, aiutare gli utenti, e molto altro.
+
+                    La comunità che opera in Italia prende il nome di
+                    <i>Mozilla Italia</i>; si occupa di tradurre progetti e siti web,
+                    ma anche di realizzare e partecipare a eventi,
+                    aiutare gli utenti, e molto altro.
                     <br>
-                    Per questi motivi chiunque è il benvenuto: la <b>collaborazione</b> è il fulcro di ogni comunità.
+
+                    Per questi motivi chiunque è il benvenuto: la
+                    <b>collaborazione</b> è il fulcro di ogni comunità.
                     <br>
-                    Trovi Mozilla Italia sia sul <i>forum</i> (<b>forum.mozillaitalia.org</b>) sia sui canali <i>Telegram</i> (<b>@mozItaHub*</b>).
+
+                    Trovi Mozilla Italia sia sul <i>forum</i>
+                    (<b>forum.mozillaitalia.org</b>) sia sui canali
+                    <i>Telegram</i> (<b>@mozItaHub*</b>).
                 </div>
             </div>
 
@@ -32,7 +51,11 @@
                     Perché scegliere Firefox?
                 </div>
                 <div id="sub_descrizione">
-                    Firefox è creato <b>dagli</b> utenti <b>per</b> gli utenti. Non è realizzato per guadagnare, Mozilla è una fondazione no profit, ma per <b>offrire</b> un'esperienza di navigazione <b>unica</b>. Scegli il browser <b>libero</b>, <b>sicuro</b>, <b>affidabile</b> e <b>indipendente</b>.
+                    Firefox è creato <b>dagli</b> utenti <b>per</b> gli utenti.
+                    Non è realizzato per guadagnare, Mozilla è una fondazione no profit,
+                    ma per <b>offrire</b> un'esperienza di navigazione <b>unica</b>.
+                    Scegli il browser <b>libero</b>, <b>sicuro</b>,
+                    <b>affidabile</b> e <b>indipendente</b>.
                     <br>
                     <font id="scegli_firefox">Scegli Firefox!</font>
                 </div>
@@ -41,7 +64,14 @@
                         Libertà e personalizzazione
                     </div>
                     <div id="descrizione">
-                        Firefox è il browser davvero “personale”. Grazie alle migliaia di estensioni disponibili è possibile aggiungere <b>nuove funzionalità</b> e, se non trovi l'estensione adatta alle tue esigenze, puoi svilupparla tu stesso. Inoltre, la moltitudine di temi disponibili consente di personalizzare anche l'interfaccia grafica e, se non dovessi trovare un tema che ti piace, puoi creare uno tutto tuo!
+                        Firefox è il browser davvero “personale”.
+                        Grazie alle migliaia di estensioni disponibili
+                        è possibile aggiungere <b>nuove funzionalità</b> e,
+                        se non trovi l'estensione adatta alle tue esigenze,
+                        puoi svilupparla tu stesso. Inoltre, la moltitudine
+                        di temi disponibili consente di personalizzare anche
+                        l'interfaccia grafica e, se non dovessi trovare
+                        un tema che ti piace, puoi creare uno tutto tuo!
                     </div>
                 </div>
                 <div id="sez2">
@@ -49,7 +79,15 @@
                         Sicurezza e privacy
                     </div>
                     <div id="descrizione">
-                        La <b>sicurezza</b> sul Web è fondamentale: Firefox integra moltissime funzioni in grado di migliorare la sicurezza della navigazione sul Web come ad esempio la protezione anti-phishing, la gestione avanzata delle password, il controllo dei cookie e le impostazioni di sicurezza personalizzate. Il sistema di aggiornamento automatico consente di mantenere il browser sempre aggiornato all’ultima versione disponibile.
+                        La <b>sicurezza</b> sul Web è fondamentale:
+                        Firefox integra moltissime funzioni in grado
+                        di migliorare la sicurezza della navigazione sul Web
+                        come ad esempio la protezione anti-phishing,
+                        la gestione avanzata delle password,
+                        il controllo dei cookie e le impostazioni di sicurezza
+                        personalizzate. Il sistema di aggiornamento automatico
+                        consente di mantenere il browser sempre aggiornato
+                        all’ultima versione disponibile.
                     </div>
                 </div>
                 <div id="sez3">
@@ -57,7 +95,11 @@
                         Velocità
                     </div>
                     <div id="descrizione">
-                        Grazie alle numerosissime innovazioni introdotte nel progetto, chiunque lo utilizzi può apprezzare la <b>velocità</b> di visualizzazione, la rapidità di esecuzione di JavaScript e la perfetta resa del testo e delle immagini nelle pagine web. Provare per credere!
+                        Grazie alle numerosissime innovazioni introdotte nel progetto,
+                        chiunque lo utilizzi può apprezzare la <b>velocità</b>
+                        di visualizzazione, la rapidità di esecuzione di JavaScript
+                        e la perfetta resa del testo e delle immagini
+                        nelle pagine web. Provare per credere!
                     </div>
                 </div>
                 <div id="sez4">
@@ -65,26 +107,43 @@
                         Supporto
                     </div>
                     <div id="descrizione">
-                        Il concetto di <i>comunità</i> è alla base della filosofia di Mozilla. Centinaia di persone in tutto il mondo collaborano alla pubblicazione di articoli di <b>supporto</b> e offrono <b>assistenza</b> agli utenti nelle principali lingue mondiali. In Italia questo compito è affidato a Mozilla Italia che offre supporto attraverso il suo forum o sui canali Telegram ufficiali.
+                        Il concetto di <i>comunità</i> è alla base della filosofia
+                        di Mozilla. Centinaia di persone in tutto il mondo collaborano
+                        alla pubblicazione di articoli di <b>supporto</b>
+                        e offrono <b>assistenza</b> agli utenti nelle principali
+                        lingue mondiali. In Italia questo compito è affidato
+                        a Mozilla Italia che offre supporto attraverso
+                        il suo forum o sui canali Telegram ufficiali.
                     </div>
                 </div>
             </div>
-            
+
             <div id="novita">
                 <div id="sub_titolo">
                     Novità
                 </div>
                 <div id="sub_descrizione">
-                    Gli aggiornamenti di Firefox mirano a migliorare l'esperienza utente, quindi aggiungendo funzionalità utili e richieste. Alcune funzionalità utili sono: la <b>Modalità lettura</b>, il <b>Pulsante dimentica</b>, la <b>Barra degli indirizzi intelligente</b>.
+                    Gli aggiornamenti di Firefox mirano a migliorare l'esperienza utente,
+                    quindi aggiungendo funzionalità utili e richieste.
+                    Alcune funzionalità utili sono: la <b>Modalità lettura</b>,
+                    il <b>Pulsante dimentica</b>,
+                    la <b>Barra degli indirizzi intelligente</b>.
                     <br>
-                    Firefox offre diverse versioni, oltre alla stabile, la <i>Dev Edition</i>, rivolta agli sviluppatori, e la <i>Nightly</i>, rivolta a chi vuole collaborare segnalando eventuali problemi.
+                    Firefox offre diverse versioni, oltre alla stabile,
+                    la <i>Dev Edition</i>, rivolta agli sviluppatori,
+                    e la <i>Nightly</i>, rivolta a chi vuole collaborare
+                    segnalando eventuali problemi.
                 </div>
                 <div id="sez1">
                     <div id="titolo">
                         WebVR
                     </div>
                     <div id="descrizione">
-                        La realtà virtuale oggi permette di sperimentare nuove possibilità, anche unita alla realtà aumentata. Queste tecnologie richiedono costosi headset ma, <b>grazie a Firefox</b>, è possibile farlo direttamente dal Web gratuitamente con la libreria JavaScript A-Frame.
+                        La realtà virtuale oggi permette di sperimentare nuove possibilità,
+                        anche unita alla realtà aumentata.
+                        Queste tecnologie richiedono costosi headset ma,
+                        <b>grazie a Firefox</b>, è possibile farlo direttamente
+                        dal Web gratuitamente con la libreria JavaScript A-Frame.
                     </div>
                 </div>
                 <div id="sez2">
@@ -92,7 +151,9 @@
                         Firefox Screenshot
                     </div>
                     <div id="descrizione">
-                        Firefox Screenshot è una nuova funzione che permette di catturare, scaricare, raccogliere e condividere immagini ("screenshot") dei siti web.
+                        Firefox Screenshot è una nuova funzione che permette di catturare,
+                        scaricare, raccogliere e condividere immagini ("screenshot")
+                        dei siti web.
                     </div>
                 </div>
                 <div id="sez3">
@@ -100,7 +161,10 @@
                         Pocket
                     </div>
                     <div id="descrizione">
-                        Pocket è un servizio integrato in Firefox che permette di salvare, in un unico posto, con un semplice clic, tutte le pagine di proprio interesse per poterle leggere, condividere o rimuovere successivamente.
+                        Pocket è un servizio integrato in Firefox che permette di salvare,
+                        in un unico posto, con un semplice clic,
+                        tutte le pagine di proprio interesse per poterle leggere,
+                        condividere o rimuovere successivamente.
                     </div>
                 </div>
             </div>

--- a/html/volantino_retro.html
+++ b/html/volantino_retro.html
@@ -5,20 +5,31 @@
         <link rel="stylesheet" href="./stile.css" />
     </head>
     <body>
-        <div id="body">    
+        <div id="body">
             <div id="estensioni">
                 <div id="sub_titolo">
                     Estensioni
                 </div>
                 <div id="sub_descrizione">
-                    Un punto di forza di Firefox sono le estensioni. La libertà e la personalizzazione del browser sono le caratteristiche di Firefox, a dimostrazione del fatto che gli utenti sono di massima importanza per Mozilla. Firefox, inoltre, è il solo browser web che dispone di estensioni anche nella versione mobile. Qui di seguito alcune delle migliori estensioni disponibili:
+                    Un punto di forza di Firefox sono le estensioni.
+                    La libertà e la personalizzazione del browser
+                    sono le caratteristiche di Firefox, a dimostrazione
+                    del fatto che gli utenti sono di massima importanza per Mozilla.
+                    Firefox, inoltre, è il solo browser web che dispone
+                    di estensioni anche nella versione mobile.
+                    Qui di seguito alcune delle migliori estensioni disponibili:
                 </div>
                 <div id="sez1">
                     <div id="titolo">
                         Facebook Container
                     </div>
                     <div id="descrizione">
-                        Questo componente aggiuntivo <b>isola</b> <i>Facebook</i>, <i>WhatsApp</i>, <i>Messenger</i> e <i>Instagram</i> impedendogli di raccogliere dati e attività registrate su altri siti. Agisce mediante un contenitore, che si attiva in automatico e identificabile da una linea blu visibile sulla scheda.
+                        Questo componente aggiuntivo <b>isola</b> <i>Facebook</i>,
+                        <i>WhatsApp</i>, <i>Messenger</i> e <i>Instagram</i>
+                        impedendogli di raccogliere dati e attività registrate
+                        su altri siti. Agisce mediante un contenitore,
+                        che si attiva in automatico e identificabile
+                        da una linea blu visibile sulla scheda.
                     </div>
                 </div>
                 <div id="sez2">
@@ -26,7 +37,10 @@
                         uBlock Origin
                     </div>
                     <div id="descrizione">
-                        Una versione alleggerita di AdBlock, impedisce il caricamento delle pubblicità e velocizza la navigazione. Mostra le statistiche sia delle risorse bloccate sia delle pubblicità bloccate della pagina che si sta visitando.
+                        Una versione alleggerita di AdBlock, impedisce
+                        il caricamento delle pubblicità e velocizza la navigazione.
+                        Mostra le statistiche sia delle risorse bloccate
+                        sia delle pubblicità bloccate della pagina che si sta visitando.
                     </div>
                 </div>
                 <div id="sez3">
@@ -34,7 +48,10 @@
                         Privacy Badger
                     </div>
                     <div id="descrizione">
-                        Privacy Badger blocca i tentativi di tracciamento sul Web (come i pulsanti di condivisione dei social network) attraverso filtri specifici che riconoscono le pagine traccianti o malevole e ne impediscono il caricamento.
+                        Privacy Badger blocca i tentativi di tracciamento sul Web
+                        (come i pulsanti di condivisione dei social network)
+                        attraverso filtri specifici che riconoscono le pagine
+                        traccianti o malevole e ne impediscono il caricamento.
                     </div>
                 </div>
                 <div id="sez4">
@@ -42,7 +59,9 @@
                         I Don't Care About Cookies
                     </div>
                     <div id="descrizione">
-                        Consente di disattivare gli avvisi dei siti, resi obbligatori da una direttiva emanata della UE, sull'utilizzo di cookie di terze parti.
+                        Consente di disattivare gli avvisi dei siti,
+                        resi obbligatori da una direttiva emanata della UE,
+                        sull'utilizzo di cookie di terze parti.
                     </div>
                 </div>
                 <div id="sez5">
@@ -50,7 +69,10 @@
                         HTTPS Everywhere
                     </div>
                     <div id="descrizione">
-                        Alcuni siti non hanno il protocollo HTTPS attivato e la navigazione, pertanto, non è protetta. Questa estensione ne forza l'attivazione, rendendo la navigazione sicura e protetta.
+                        Alcuni siti non hanno il protocollo HTTPS attivato
+                        e la navigazione, pertanto, non è protetta.
+                        Questa estensione ne forza l'attivazione,
+                        rendendo la navigazione sicura e protetta.
                     </div>
                 </div>
                 <div id="sez6">
@@ -58,24 +80,41 @@
                         History AutoDelete
                     </div>
                     <div id="descrizione">
-                        Grazie a questa estensione è possibile pulire la cronologia di navigazione periodicamente secondo i propri gusti in maniera automatica e programmata.
+                        Grazie a questa estensione è possibile pulire la cronologia
+                        di navigazione periodicamente secondo i propri gusti
+                        in maniera automatica e programmata.
                     </div>
                 </div>
             </div>
-            
+
             <div id="altri_progetti_mozilla">
                 <div id="sub_titolo">
                     Altri progetti Mozilla
                 </div>
                 <div id="sub_descrizione">
-                    Numerosi sono i progetti portati avanti dalla Mozilla Foundation e tra quelli non elencati ci sono altri innumerevoli progetti, come, ad esempio MDN, Open Leadership e Internet Health Report. Tutti, comunque, si rivolgono a persone con differenti competenze e hanno tutti un fattore in comune: la visione del <b>web come risorsa aperta a chiunque</b>. In dettaglio i progetti più considerevoli di Mozilla:
+                    Numerosi sono i progetti portati avanti dalla Mozilla Foundation
+                    e tra quelli non elencati ci sono altri innumerevoli progetti,
+                    come, ad esempio MDN, Open Leadership e Internet Health Report.
+                    Tutti, comunque, si rivolgono a persone con differenti
+                    competenze e hanno tutti un fattore in comune: la visione
+                    del <b>web come risorsa aperta a chiunque</b>.
+                    In dettaglio i progetti più considerevoli di Mozilla:
                 </div>
                 <div id="sez1">
                     <div id="titolo">
                         Firefox Focus
                     </div>
                     <div id="descrizione">
-                        Firefox Focus è un nuovo progetto della Mozilla Foundation che porta la navigazione privata a un livello più alto, fornendo un browser dedicato alla privacy, attraverso un evoluto sistema di protezione antitracciamento e di blocco dei contenuti. Le avanzate funzionalità per la protezione della privacy sono sempre attive e la cronologia di navigazione, come anche i dati raccolti, vengono eliminati automaticamente al termine di ogni sessione di navigazione. Tutte queste caratteristiche avanzate sono disponibili in <b>soli 5 MB</b>, sia per Android sia per iOS.
+                        Firefox Focus è un nuovo progetto della Mozilla Foundation
+                        che porta la navigazione privata a un livello più alto,
+                        fornendo un browser dedicato alla privacy, attraverso
+                        un evoluto sistema di protezione antitracciamento
+                        e di blocco dei contenuti. Le avanzate funzionalità
+                        per la protezione della privacy sono sempre attive
+                        e la cronologia di navigazione, come anche i dati raccolti,
+                        vengono eliminati automaticamente al termine di ogni sessione
+                        di navigazione. Tutte queste caratteristiche avanzate
+                        sono disponibili in <b>soli 5 MB</b>, sia per Android sia per iOS.
                     </div>
                 </div>
                 <div id="sez2">
@@ -83,30 +122,50 @@
                         Test Pilot
                     </div>
                     <div id="descrizione">
-                        Test Pilot è un progetto sviluppato da Mozilla e permette agli utenti di essere, in tutte le fasi di sviluppo, al centro del progetto Firefox, testando periodicamente delle estensioni sperimentali: si possono provare in anteprima delle possibili future funzionalità, prima che queste vengano integrate nel browser stesso e, quindi, disponibili per tutti. Dopo averlo installato è possibile scegliere ciò che si desidera provare, quindi collaborare rilasciando una <b>propria opinione</b> sull’esperienza d’uso personale. Vieni a scoprire le nuove funzionalità sperimentali su: <i>https://testpilot.firefox.com/</i>
+                        Test Pilot è un progetto sviluppato da Mozilla
+                        e permette agli utenti di essere, in tutte le fasi di sviluppo,
+                        al centro del progetto Firefox, testando periodicamente
+                        delle estensioni sperimentali: si possono provare
+                        in anteprima delle possibili future funzionalità,
+                        prima che queste vengano integrate nel browser stesso e,
+                        quindi, disponibili per tutti. Dopo averlo installato
+                        è possibile scegliere ciò che si desidera provare,
+                        quindi collaborare rilasciando una <b>propria opinione</b>
+                        sull’esperienza d’uso personale. Vieni a scoprire le
+                        nuove funzionalità sperimentali su: <i>https://testpilot.firefox.com/</i>
                     </div>
                 </div>
             </div>
-            
+
             <div id="unisciti">
                 <div id="titolo">
                     Vuoi contribuire?
                 </div>
                 <div id="descrizione">
-                    <b>Il tuo aiuto è fondamentale per mantenere il Web una risorsa libera, accessibile e pubblica.</b>
+                    <b>Il tuo aiuto è fondamentale per mantenere il Web una risorsa
+                       libera, accessibile e pubblica.</b>
                     <br>
-                    I nostri <b>volontari</b> quotidianamente lavorano affinché questo sia possibile. Non è necessario che tu abbia delle abilità specifiche. Tra di noi potrai confrontarti con grafici, ingegneri, informatici, linguisti, studenti e insegnanti. Il nostro fattore comune è la volontà e la consapevolezza che <b>l’unione fa la forza</b>.  
+                    I nostri <b>volontari</b> quotidianamente lavorano affinché
+                    questo sia possibile. Non è necessario che tu abbia delle abilità specifiche.
+                    Tra di noi potrai confrontarti con grafici, ingegneri, informatici,
+                    linguisti, studenti e insegnanti. Il nostro fattore comune è
+                    la volontà e la consapevolezza che <b>l’unione fa la forza</b>.
                     <br>
-                    Saremo a tua disposizione e disponibili ad aiutarti lungo tutto questo tuo fantastico percorso all’interno della nostra community italiana. Per conoscere meglio tutto questo, apprendere nuove competenze e contribuire a migliorare il Web, visita <i>http://mozillaitalia.org!</i>
+                    Saremo a tua disposizione e disponibili ad aiutarti
+                    lungo tutto questo tuo fantastico percorso all’interno
+                    della nostra community italiana.
+                    Per conoscere meglio tutto questo, apprendere nuove competenze
+                    e contribuire a migliorare il Web, visita <i>http://mozillaitalia.org!</i>
                 </div>
             </div>
-            
+
             <div id="collaboratori">
                 <div id="titolo">
                     Collaboratori
                 </div>
                 <div id="descrizione">
-                    Cantu Niccolo, De Rose Pasquale, Morelli Saverio, Pignataro Giuseppe, Pirrotta Irene, Pizii Mirko, Putti Edoardo, Scasciafratte Daniele, Viola Edoardo
+                    Cantu Niccolo, De Rose Pasquale, Morelli Saverio, Pignataro Giuseppe,
+                    Pirrotta Irene, Pizii Mirko, Putti Edoardo, Scasciafratte Daniele, Viola Edoardo
                 </div>
             </div>
         </div>

--- a/vademecum.md
+++ b/vademecum.md
@@ -52,14 +52,14 @@ Firefox offre diverse versioni, oltre alla stabile, la _Dev Edition_, rivolta ag
 La realtà virtuale oggi permette di sperimentare nuove possibilità, anche unita alla realtà aumentata.
 Queste tecnologie richiedono costosi headset ma, **grazie a Firefox**, è possibile farlo direttamente dal Web gratuitamente con la libreria JavaScript A-Frame.
 
-##### Firefox Screenshot 
- 
-Firefox Screenshot è una nuova funzione che permette di catturare, scaricare, raccogliere e condividere immagini ("screenshot") dei siti web. 
- 
-##### Pocket 
- 
+##### Firefox Screenshot
+
+Firefox Screenshot è una nuova funzione che permette di catturare, scaricare, raccogliere e condividere immagini ("screenshot") dei siti web.
+
+##### Pocket
+
 Pocket è un servizio integrato in Firefox che permette di salvare, in un unico posto, con un semplice clic, tutte le pagine di proprio interesse per poterle leggere, condividere o rimuovere successivamente.
- 
+
 ### Estensioni
 Un punto di forza di Firefox sono le estensioni. La libertà e la personalizzazione del browser sono le caratteristiche di Firefox, a dimostrazione del fatto che gli utenti sono di massima importanza per Mozilla. Firefox, inoltre, è il solo browser web che dispone di estensioni anche nella versione mobile. Qui di seguito alcune delle migliori estensioni disponibili:
 
@@ -83,7 +83,7 @@ Grazie a questa estensione è possibile pulire la cronologia di navigazione peri
 
 ### Altri progetti Mozilla
 
-Numerosi sono i progetti portati avanti dalla Mozilla Foundation e tra quelli non elencati ci sono altri innumerevoli progetti, come, ad esempio MDN, Open Leadership e Internet Health Report. Tutti, comunque, si rivolgono a persone con differenti competenze e hanno tutti un fattore in comune: la visione del **Web come risorsa aperta a chiunque**. In dettaglio i progetti più considerevoli di Mozilla:
+Numerosi sono i progetti portati avanti dalla Mozilla Foundation e tra quelli non elencati ci sono altri innumerevoli progetti come: MDN, Open Leadership e Internet Health Report. Tutti, comunque, si rivolgono a persone con differenti competenze e hanno tutti un fattore in comune: la visione del **Web come risorsa aperta a chiunque**. In dettaglio i progetti più considerevoli di Mozilla:
 
 ##### Firefox Focus
 


### PR DESCRIPTION
nella sezione altri progetti mozilla c'era ", come, ad esempio MND" che mi sembra una ripetizione di uno stesso concetto senza motivo. Semplicemnte ho tolto ad esempio