### PR TITLE
tolto 'ad esempio' da altri progetti firefox

### DIFF
--- a/vademecum.md
+++ b/vademecum.md
@@ -83,7 +83,7 @@ Grazie a questa estensione è possibile pulire la cronologia di navigazione peri
 
 ### Altri progetti Mozilla
 
-Numerosi sono i progetti portati avanti dalla Mozilla Foundation e tra quelli non elencati ci sono altri innumerevoli progetti, come, ad esempio MDN, Open Leadership e Internet Health Report. Tutti, comunque, si rivolgono a persone con differenti competenze e hanno tutti un fattore in comune: la visione del **Web come risorsa aperta a chiunque**. In dettaglio i progetti più considerevoli di Mozilla:
+Numerosi sono i progetti portati avanti dalla Mozilla Foundation e tra quelli non elencati ci sono altri innumerevoli progetti, come MDN, Open Leadership e Internet Health Report. Tutti, comunque, si rivolgono a persone con differenti competenze e hanno tutti un fattore in comune: la visione del **Web come risorsa aperta a chiunque**. In dettaglio i progetti più considerevoli di Mozilla:
 
 ##### Firefox Focus
 


### PR DESCRIPTION
[PR #107 fatta per bene]
Nella sezione altri progetti Mozilla c'era ", come, ad esempio MDN" che mi sembra una ripetizione di uno stesso concetto senza motivo. Semplicemente ho tolto ad esempio.

P.S. Scusate per la spam nella mail ( e per i typo che stanno dappertutto)
